### PR TITLE
Revert "Add classifiers and keywords to setup.py"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,22 +38,4 @@ setup(
                       'numpy<1.16.3,>1.16.0'],
     include_package_data=True,
     zip_safe=False,
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: POSIX',
-        'Operating System :: POSIX :: Linux',
-
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-
-        'Topic :: System :: Filesystems',
-    ],
-
-    keywords='filesystem hdfs chainer development',  # Optional
 )


### PR DESCRIPTION
Reverts chainer/chainerio#5 since it introduces a bug into setup.py, will add it after the activation of CI