### PR TITLE
Add tox

### DIFF
--- a/.pfnci/Dockerfile
+++ b/.pfnci/Dockerfile
@@ -1,9 +1,0 @@
-FROM chainer/chainer:latest-python3
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    python3-dev python3-pip zlib1g-dev make cmake g++ git \
-    && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
-
-RUN python3 -m pip install --no-cache-dir setuptools

--- a/.pfnci/docker/Dockerfile
+++ b/.pfnci/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="tianqi@preferred.jp"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev wget python-openssl git ca-certificates && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ cmake make libffi-dev
+
+COPY install.sh /tmp/install.sh
+
+RUN bash -c /tmp/install.sh
+
+RUN apt-get remove -y gcc g++ cmake make libreadline-dev python-openssl && apt-get -y autoremove

--- a/.pfnci/docker/Dockerfile
+++ b/.pfnci/docker/Dockerfile
@@ -13,4 +13,4 @@ COPY install.sh /tmp/install.sh
 
 RUN bash -c /tmp/install.sh
 
-RUN apt-get remove -y gcc g++ cmake make libreadline-dev python-openssl && apt-get -y autoremove
+RUN apt-get remove -y gcc g++ cmake libreadline-dev python-openssl && apt-get -y autoremove

--- a/.pfnci/docker/install.sh
+++ b/.pfnci/docker/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function install_py()
+{
+    PYTHON_VERSION=$1
+    PYENV_ROOT=$2
+    CFLAGS=-I/usr/include/openssl
+    LDFLAGS=-L/usr/lib pyenv install $PYTHON_VERSION
+    pyenv shell $PYTHON_VERSION
+    pyenv global $PYTHON_VERSION
+}
+
+python_versions=('3.5.7' '3.6.8' '3.7.2')
+PYENV_ROOT=/root/.pyenv
+
+rm -rf $PYENV_ROOT
+git clone git://github.com/pyenv/pyenv.git $PYENV_ROOT
+export PATH=$PYENV_ROOT/bin:$PATH
+export MAKE_OPTS=-j16
+$PYENV_ROOT/plugins/python-build/install.sh
+eval "$(pyenv init -)"
+echo "export PATH=$PYENV_ROOT/bin:$PATH" >> /root/.bashrc
+echo "eval '$(pyenv init -)'" >> /root/.bashrc
+# remove the return on non-interactive bash
+sed -i '6d' /root/.bashrc
+
+for version in "${python_versions[@]}"
+do
+    install_py $version $PYENV_ROOT
+done
+
+# install tox in the newest python
+pip install tox

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -10,4 +10,6 @@ docker run --interactive --rm \
 source /root/.bashrc
 pyenv global 3.5.7 3.6.8 3.7.2
 tox
+pip install sphinx
+cd docs && make html
 EOD

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -5,12 +5,9 @@ gcloud auth configure-docker
 
 docker run --interactive --rm \
        --volume "$(pwd):/repo/" --workdir /repo/ \
-       tianqixu/chainerio \
-       sh -ex << EOD
-pip3 install --user -e .
-py.test tests -s -v
-flake8 chainerio
-flake8 tests
-autopep8 -r chainerio tests --diff | tee check_autopep8
-test ! -s check_autopep8
+       chainer/chainerio:latest \
+       bash << EOD
+source /root/.bashrc
+pyenv global 3.5.7 3.6.8 3.7.2
+tox
 EOD

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     classifiers=[],
     packages=find_packages(),
     package_data={'chainerio' : package_data},
-    extras_require={'test':['pytest', 'flake8']},
+    extras_require={'test':['pytest', 'flake8', 'autopep8']},
     python_requires=">=3.5",
     install_requires=['krbticket', 'pyarrow',
                       # Workaround until https://github.com/chainer/chainer/pull/4534 gets released

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py35,py36,py37
+
+[testenv]
+deps = .[test]
+skipsdist = True
+setenv = 
+        HOME = "/root"
+commands =
+	pytest tests -s -v
+	flake8 chainerio
+	flake8 tests
+	autopep8 -r chainerio tests --diff


### PR DESCRIPTION
This PR changes the CI setting to use tox to test different python
versions that are supported by ChainerIO. The latest patched version of
each minor version are tested.
Currently, we test the following:
3.5.7
3.6.8
3.7.2
