### PR TITLE
Add fs detection test on containers

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -84,7 +84,7 @@ class TestContext(unittest.TestCase):
         zip_file_name = "test"
         zip_file_path = zip_file_name + ".zip"
 
-        # TODO(tianqi): add functionality ot chainerio 
+        # TODO(tianqi): add functionality ot chainerio
         from pyarrow import hdfs
 
         conn = hdfs.connect()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -63,6 +63,50 @@ class TestContext(unittest.TestCase):
 
         chainerio.remove(zip_file_path)
 
+    def test_fs_detection_on_container_posix(self):
+        # Create a container for testing
+        zip_file_name = "test"
+        zip_file_path = zip_file_name + ".zip"
+        posix_file_path = "file://" + zip_file_path
+
+        shutil.make_archive(zip_file_name, "zip", base_dir=self.dir_name)
+
+        with chainerio.open_as_container(posix_file_path) as container:
+            with container.open(self.tmpfile_path, "r") as f:
+                self.assertEqual(
+                    f.read(), self.test_string_str)
+
+        chainerio.remove(zip_file_path)
+
+    @unittest.skipIf(shutil.which('hdfs') is None, "HDFS client not installed")
+    def test_fs_detection_on_container_hdfs(self):
+        # Create a container for testing
+        zip_file_name = "test"
+        zip_file_path = zip_file_name + ".zip"
+
+        # TODO(tianqi): add functionality ot chainerio 
+        from pyarrow import hdfs
+
+        conn = hdfs.connect()
+        hdfs_home = conn.info('.')['path']
+        conn.close()
+
+        hdfs_file_path = os.path.join(hdfs_home, zip_file_path)
+
+        shutil.make_archive(zip_file_name, "zip", base_dir=self.dir_name)
+
+        with chainerio.open(hdfs_file_path, "wb") as hdfs_file:
+            with chainerio.open(zip_file_path, "rb") as posix_file:
+                hdfs_file.write(posix_file.read())
+
+        with chainerio.open_as_container(hdfs_file_path) as container:
+            with container.open(self.tmpfile_path, "r") as f:
+                self.assertEqual(
+                    f.read(), self.test_string_str)
+
+        chainerio.remove(zip_file_path)
+        chainerio.remove(hdfs_file_path)
+
     def test_root_local_override(self):
         chainerio.set_root('file://' + self.dir_name)
         print(self.tmpfile_name)


### PR DESCRIPTION
This commit adds tests to verify if the fs detection also works when we
deal with containers.
for example:
	"file://some/container.zip"
	"hdfs:///another/container.zip"

This PR solves #11 