### PR TITLE
Remove CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-## 0.0.5
-
-- Add documents and descriptions
-- Add more tests


### PR DESCRIPTION
This commit revert the change to add CHANGELOG.md.
We keep change logs in the release logs to match the chainer style.