### PR TITLE
Bugfix for sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath('../../'))
 # sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 # -- Project information -----------------------------------------------------
@@ -46,6 +47,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
 ]
+
+autodoc_mock_imports = ['chainer']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -198,7 +198,7 @@ File-like Objects
 Abstraction of binary objects or files, typically returned by
 ``fs.open`` method. It is an implementation of ``RawIOBase`` class
 (See `RawIOBase
-<https://docs.python.org/3/library/io.html#io.RawIOBase>`_ in Python
+<https://docs.python.org/3/library/io.html#io.RawIOBase>`__ in Python
 document). It supports
 
 - Read to underlying file or binary in a container


### PR DESCRIPTION
This commit fixes the following bugs which fail the API documentation
build using sphinx.
1. Enforce the error check. Fail the build when sphinx generates any
warning. This is because sphinx considers import failure as warning,
which it should be an error and fail the build.
2. Fix import error. Fix the wrong sys.path to include the `ChainerIO`
itself, and uses mock to include `Chainer`.
3. Fix some warning/error in the links