### PR TITLE
Not to use the root logger, to prevent affecting to loggers outside chainerio

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -6,6 +6,9 @@ import logging
 import os
 import zipfile
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
 
 class ZipFileObject(FileObject):
     def __init__(self, base_file_object, base_filesystem_handler,
@@ -26,7 +29,7 @@ class ZipContainer(Container):
         Container.__init__(self, base_handler, base)
         self._check_zip_file_name(base)
 
-        logging.info("using zip container for {}".format(base))
+        logger.info("using zip container for {}".format(base))
         self.zip_file_obj = None
         self.type = "zip"
         self.fileobj_class = ZipFileObject

--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -10,6 +10,9 @@ import os
 import pyarrow
 from pyarrow import hdfs
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
 
 class HdfsFileObject(FileObject):
     def __init__(self, base_file_object, base_filesystem_handler,
@@ -45,7 +48,7 @@ class HdfsFileSystem(FileSystem):
 
     def _create_connection(self):
         if None is self.connection:
-            logging.debug('creating connection')
+            logger.debug('creating connection')
 
             if None is not self.keytab_path:
                 self.ticket = KrbTicket.init(

--- a/chainerio/profiler/io_profiler.py
+++ b/chainerio/profiler/io_profiler.py
@@ -2,6 +2,9 @@ import logging
 import os
 import time
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+
 
 class IOProfiler(object):
     def __init__(self,
@@ -21,9 +24,9 @@ class IOProfiler(object):
         if self.profiling\
                 and not os.path.exists(self.log_base_path):
             self.log_base_path = "/tmp/"
-            logging.info("profile I/O")
+            logger.info("profile I/O")
         else:
-            logging.info("do not profile I/O")
+            logger.info("do not profile I/O")
 
     def start_record(self, mode="READ"):
         if self.profiling:


### PR DESCRIPTION
Directly calling `logging.{debug,info,...}` is known to cause of strange behaviors of other loggers outside the module, therefore it is suggested not to do so when developing a library.

> For libraries that want to perform logging, you should create a dedicated logger object,and initially configure it as follows:
> ```
> # somelib.py
> importlogging
> log = logging.getLogger(__name__)
> log.addHandler(logging.NullHandler())
> ```
> -- _Python Cookbook 3rd edition pp. 558_
>     _https://d.cxcore.net/Python/Python_Cookbook_3rd_Edition.pdf_

What is actually wrong with the root logger use?
The below short code snippet is a minimum explanation of a typical phenomenon (py3.6.7).
Exactly the same thing happened to me when using chainerio in my application code that also uses Python logging without directly calling the root logger.

```python
import sys, logging

# Prepare for my logger outside chainerio
logger = logging.getLogger('hello log')
handler = logging.StreamHandler(sys.stderr)
handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
logger.addHandler(handler)
logger.setLevel("INFO")

logger.info("First log")
logging.debug('this is direct log')             # Directly calling logging.debug as chainerio does
logger.info("Second log")
logger.info("Third log")
```

```
2019-06-26 20:48:34,549 INFO hello log: First log      # <----- OK
2019-06-26 20:48:34,549 INFO hello log: Second log     # <----- OK
INFO:hello log:Second log                              # !?
2019-06-26 20:48:34,549 INFO hello log: Third log
INFO:hello log:Third log
```

This PR is just to replace all the direct use of the root logger to module local loggers as suggested in the Python Cookbook. I checked that this worked for my case, but I haven't tested it thoroughly.