### PR TITLE
Change the supported python version to 3.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     package_data={'chainerio' : package_data},
     extras_require={'test':['pytest', 'flake8', 'autopep8']},
-    python_requires=">=3.5",
+    python_requires=">=3.5.3",
     install_requires=['krbticket', 'pyarrow'],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This commit changes the supported python version from 3.5 to 3.5.3

A bug in type hint in Python 3.5.2, which cause the chainerio to raise error,
was fixed 3.5.3
For more details, please see
https://stackoverflow.com/questions/42942867/optionaltypefoo-raises-typeerror-in-python-3-5-2

This closes #28 