### PR TITLE
Add seekable and readable into fileobject

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -26,8 +26,9 @@ class ZipFileObject(FileObject):
             # difficult since making a zip requires the file to be seekable.
             # As a workaround we put the data into BytesIO object.
 
-            warnings.warn('Chainerio reads the whole file content from zip '
-                          'on opening, which might cause performance or '
+            warnings.warn('In the current Python, Chainerio has to read '
+                          'the whole file content from the zip '
+                          'on open, which might cause performance or '
                           'memory issues. '
                           'Use Python >= 3.7 to avoid.',
                            RuntimeWarning)

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -1,6 +1,7 @@
 from chainerio.container import Container
 from chainerio.fileobject import FileObject
 from chainerio.io import open_wrapper
+import warnings
 import io
 import logging
 import os
@@ -20,11 +21,18 @@ class ZipFileObject(FileObject):
             base_file_object = io.TextIOWrapper(base_file_object,
                                                 encoding, errors, newline)
         elif sys.version_info < (3, 7, ):
-            # In the old implemetaion of zipfile before Python 3.7, 
-            # the ZipExtFile was not seekable, which makes nested zip 
+            # In the old implemetaion of zipfile before Python 3.7,
+            # the ZipExtFile was not seekable, which makes nested zip
             # difficult since making a zip requires the file to be seekable.
             # As a workaround we put the data into BytesIO object.
-            base_file_object = io.BytesIO(base_file_object.read()) 
+
+            warnings.warn('Chainerio reads the whole file content from zip '
+                          'on opening, which might cause performance or '
+                          'memory issues. '
+                          'Use Python >= 3.7 to avoid.',
+                           RuntimeWarning)
+
+            base_file_object = io.BytesIO(base_file_object.read())
 
         FileObject.__init__(self, base_file_object, base_filesystem_handler,
                             path, mode, buffering, encoding, errors, newline,

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import zipfile
+import sys
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
@@ -18,6 +19,12 @@ class ZipFileObject(FileObject):
         if 'b' not in mode:
             base_file_object = io.TextIOWrapper(base_file_object,
                                                 encoding, errors, newline)
+        elif sys.version_info < (3, 7, ):
+            # In the old implemetaion of zipfile before Python 3.7, 
+            # the ZipExtFile was not seekable, which makes nested zip 
+            # difficult since making a zip requires the file to be seekable.
+            # As a workaround we put the data into BytesIO object.
+            base_file_object = io.BytesIO(base_file_object.read()) 
 
         FileObject.__init__(self, base_file_object, base_filesystem_handler,
                             path, mode, buffering, encoding, errors, newline,

--- a/chainerio/fileobject.py
+++ b/chainerio/fileobject.py
@@ -27,6 +27,9 @@ class FileObject(io.IOBase):
 
     def seekable(self) -> bool:
         return self.base_file_object.seekable()
+    
+    def readable(self) -> bool:
+        return self.base_file_object.readable()
 
     def seek(self, pos: int, whence: int = 0) -> int:
         return self.base_file_object.seek(pos, whence)

--- a/chainerio/fileobject.py
+++ b/chainerio/fileobject.py
@@ -25,6 +25,9 @@ class FileObject(io.IOBase):
         self.closefd = closefd
         self.opener = opener
 
+    def seekable(self) -> bool:
+        return self.base_file_object.seekable()
+
     def seek(self, pos: int, whence: int = 0) -> int:
         return self.base_file_object.seek(pos, whence)
 


### PR DESCRIPTION
This commit adds seekable and readable function into fileobject, which was missing.
These two functions are often used by other libraries for switching behavior for different underlying file system. 
Missing forwarding of those functions can cause some libraries not work properly with ChainerIO. 
For example, zipfile binds its seekable attribute to the underlying filesystem and it checks the zip file by seeking in `init`, missing the seekable function can cause nested zip cannot be correctly opened, as the `nested zip` fails to be seekable, which requires by the zipfile init module