### PR TITLE
Nested Zip Support for Python<3.7

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -47,12 +47,11 @@ class ZipContainer(Container):
                 # for user.
 
                 warnings.warn('In Python < 3.7, '
-                              'To support opeing nested zip as container, '
-                              'Chainerio has to read '
+                              'To support opening nested zip as container, '
+                              'ChainerIO has to read '
                               'the entire nested zip upon open, '
                               'which might cause performance or '
-                              'memory issues when the nested zip is huge.'
-                              'Use Python >= 3.7 to avoid.',
+                              'memory issues when the nested zip is huge.',
                               category=RuntimeWarning)
                 zip_file = io.BytesIO(zip_file.read())
 

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -11,30 +11,43 @@ from zipfile import ZipFile
 class TestZipHandler(unittest.TestCase):
 
     def setUp(self):
-
+        # The following zip layout is created for all the tests
+        # outside.zip
+        # | - testdir
+        # |   | - nested.zip
+        # |   |   | - nested_dir
+        # |   |   |   | - nested
+        # |   | - testfile
         self.test_string = "this is a test string\n"
         self.nested_test_string = \
             "this is a test string for nested zip\n"
         self.test_string_b = self.test_string.encode("utf-8")
         self.nested_test_string_b = \
             self.nested_test_string.encode("utf-8")
-        self.zip_file_name = "test"
+
+        # the most outside zip
+        self.zip_file_name = "outside"
         self.zip_file_path = self.zip_file_name + ".zip"
+
+        # nested zip and nested file
         self.nested_zipped_file_name = "nested"
+        self.nested_dir_name = "nested_dir/"
         self.nested_zip_file_name = "nested.zip"
+
+        # directory and file
         self.dir_name = "testdir/"
         self.zipped_file_name = "testfile"
+
         self.zipped_file_path = os.path.join(
             self.dir_name, self.zipped_file_name)
         self.nested_zip_path = os.path.join(
             self.dir_name, self.nested_zip_file_name)
         self.nested_zipped_file_path = os.path.join(
-            self.dir_name, self.nested_zipped_file_name)
+            self.nested_dir_name, self.nested_zipped_file_name)
         self.fs_handler = chainerio.create_handler("posix")
 
-        if os.path.exists(self.dir_name):
-            shutil.rmtree(self.dir_name)
         os.mkdir(self.dir_name)
+        os.mkdir(self.nested_dir_name)
         with open(self.zipped_file_path, "w") as tmpfile:
             tmpfile.write(self.test_string)
 
@@ -49,10 +62,9 @@ class TestZipHandler(unittest.TestCase):
         shutil.make_archive(self.zip_file_name, "zip", base_dir=self.dir_name)
 
     def tearDown(self):
-        os.remove(self.zipped_file_path)
         os.remove(self.zip_file_path)
-        os.remove(self.nested_zip_path)
-        os.rmdir(self.dir_name)
+        shutil.rmtree(self.dir_name)
+        shutil.rmtree(self.nested_dir_name)
 
     def test_read_bytes(self):
         with self.fs_handler.open_as_container(


### PR DESCRIPTION
This PR adds nested zip support for Python< 3.7.
As described in #41, Unlike the Python > 3.7, due to implementation issues in Python,
the nested zip support is not enabled by default.
This PR introduces a workaround to enable nested zip access in Python <3.7 as follow:

When accessing nested zip with Python< 3.7, the whole nested zip file is read and put into a `BytesIO` object to add `seekable` to the file object to create the corresponding `ZipFile` object. 


This workaround can introduce performance and memory consumption issues when the nested zip file is huge and a small portion of the nested zip is actually needed.
A warning message is generated in that case.

Tests for nested zip are also added in this PR.
This PR solves the 2nd problem in #37, i.e. #41.