### PR TITLE
Improve pickle performance on HDFS

### DIFF
--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -62,6 +62,8 @@ class HdfsFileSystem(FileSystem):
 
         if 'b' not in mode:
             file_obj = io.TextIOWrapper(file_obj, encoding, errors, newline)
+        elif 'r' in mode:
+            file_obj = io.BufferedReader(file_obj)
 
         return file_obj
 

--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -63,11 +63,10 @@ class HdfsFileSystem(FileSystem):
         if 'b' not in mode:
             file_obj = io.TextIOWrapper(file_obj, encoding, errors, newline)
         elif 'r' in mode:
-            # wrap the file_obj with io.BufferedReader to add `peek` support,
-            # which signiciantly improve pickle performance.
+            # Wrapping file_obj with io.BufferedReader to add `peek` support,
+            # which signiciantly improves unpickle performance.
             file_obj = io.BufferedReader(file_obj)
         else:
-            # wrap the file_obj with io.BufferedWriter
             file_obj = io.BufferedWriter(file_obj)
 
         return file_obj

--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -65,8 +65,10 @@ class HdfsFileSystem(FileSystem):
         elif 'r' in mode:
             # wrap the file_obj with io.BufferedReader to add `peek` support,
             # which signiciantly improve pickle performance.
-
             file_obj = io.BufferedReader(file_obj)
+        else:
+            # wrap the file_obj with io.BufferedWriter
+            file_obj = io.BufferedWriter(file_obj)
 
         return file_obj
 

--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -63,6 +63,9 @@ class HdfsFileSystem(FileSystem):
         if 'b' not in mode:
             file_obj = io.TextIOWrapper(file_obj, encoding, errors, newline)
         elif 'r' in mode:
+            # wrap the file_obj with io.BufferedReader to add `peek` support,
+            # which signiciantly improve pickle performance.
+
             file_obj = io.BufferedReader(file_obj)
 
         return file_obj


### PR DESCRIPTION
This PR improves the pickle performance described in #42. closes #42.

In order to add the missing `peek` support, the HdfsFile object gets
wrapped with `io.BufferedReader` when opening with 'rb',
which is how the file is opened when using pickle.

Before (from #42) :
```
$ python test.py
chainerio:  186.07044076919556
```

with this PR
```
$ python test.py
chainerio:  47.654032945632935
```