### PR TITLE
Fix bugs in `list` in zip

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -79,15 +79,22 @@ class ZipContainer(Container):
         return self._list(path_or_prefix)
 
     def _list(self, path_or_prefix: str = None):
-        _list = set()
-        for name in self.zip_file_obj.namelist():
-            if path_or_prefix and name.startswith(path_or_prefix):
-                name = name[len(path_or_prefix):]
+        if path_or_prefix is None:
+            # in defult case, print the whole list
+            for name in self.zip_file_obj.namelist():
+                yield name
 
-            first_level_file_name = name.split("/")[0]
-            if first_level_file_name and first_level_file_name not in _list:
-                _list.add(first_level_file_name)
-                yield first_level_file_name
+        else:
+            _list = set()
+            for name in self.zip_file_obj.namelist():
+                if path_or_prefix and name.startswith(path_or_prefix):
+                    name = name[len(path_or_prefix):]
+
+                first_level_file_name = name.split("/")[0]
+                if first_level_file_name and \
+                        first_level_file_name not in _list:
+                    _list.add(first_level_file_name)
+                    yield first_level_file_name
 
     def set_base(self, base):
         Container.reset_base_handler(self, base)

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -56,8 +56,9 @@ class TestZipHandler(unittest.TestCase):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
             zip_generator = handler.list()
             zip_list = list(zip_generator)
-            self.assertIn(self.dir_name.split("/")[0], zip_list)
-            self.assertNotIn(self.zipped_file_name, zip_list)
+            self.assertIn(self.dir_name, zip_list)
+            self.assertIn(os.path.join(self.dir_name, self.zipped_file_name),
+                          zip_list)
             self.assertNotIn("", zip_list)
 
             zip_generator = handler.list(self.dir_name)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -43,8 +43,8 @@ class TestContext(unittest.TestCase):
         with chainerio.open_as_container(zip_file_path) as container:
             file_generator = container.list()
             file_list = list(file_generator)
-            self.assertIn(self.dir_name[:-1], file_list)
-            self.assertNotIn(self.tmpfile_path, file_list)
+            self.assertIn(self.dir_name, file_list)
+            self.assertIn(self.tmpfile_path, file_list)
             self.assertNotIn("", file_list)
 
             file_generator = container.list(self.dir_name)


### PR DESCRIPTION
This PR fixes an inconsistency between the API designed behavior
and the actual implementation in `list` of zip.

As described in [__init__.py](https://github.com/chainer/chainerio/blob/65a5d263f72e195bdfdcf33d28944438a902c301/chainerio/__init__.py#L18), in case of containers, in default case when `None` is given as `path_or_prefix`, the `list()` behaves the same as `namelist()` in zipfile.
However, the current implementation does not follow that description and `list()` with `None` return a name list of first level files. Although such behavior matches the POSIX, getting a whole list of files in containers is necessary in many cases as described in #43 .
This PR fixes the such inconsistency and match the behavior to the doc string.

This PR closes #43 