### PR TITLE
Add recursive to zip list

### DIFF
--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -15,17 +15,24 @@ def open_as_container(path: str) -> IO:
     return default_context.open_as_container(path)
 
 
-def list(path_or_prefix: Optional[str] = None) -> Iterator:
+def list(path_or_prefix: Optional[str] = None,
+         recursive: bool = True) -> Iterator:
     """list all the files under the given path_or_prefix
 
-    The default value for parameter of list is None
-    When we get the default value None, list behave similar to
-    the default os.listdir: it shows the content under the root directory,
-    which is set to local $HOME, as the default value.
-    Please note that the meaning of $HOME depends on each filesystem.
-    For example in case of any containers, it behaves like the namelist().
-    However, if a `path_or_prefix` is given,
-    then it shows all the files that start with `path_or_prefix`
+    Args:
+       path_or_prefix (str): The path to list against.
+           When we get the default value, list behave similar to
+           the default os.listdir: it shows the content under
+           the root directory, which is set to local $HOME,
+           as the default value.
+           Please note that the meaning of $HOME depends on each filesystem.
+           However, if a `path_or_prefix` is given,
+           then it shows all the files that start with `path_or_prefix`
+
+       recursive (bool): When set, list files and directories
+           recursively. Performance issues might occur for huge directories.
+           Mostly useful for containers such as zip.
+
     """
 
     global _DEFAULT_CONTEXT

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -74,20 +74,23 @@ class ZipContainer(Container):
         self._open_zip_file()
         return self.zip_file_obj.getinfo(path)
 
-    def list(self, path_or_prefix: str = None):
+    def list(self, path_or_prefix: str = "", recursive=False):
         self._open_zip_file()
-        return self._list(path_or_prefix)
 
-    def _list(self, path_or_prefix: str = None):
-        _list = set()
-        for name in self.zip_file_obj.namelist():
-            if path_or_prefix and name.startswith(path_or_prefix):
-                name = name[len(path_or_prefix):]
+        if recursive:
+            for name in self.zip_file_obj.namelist():
+                yield name
+        else:
+            _list = set()
+            for name in self.zip_file_obj.namelist():
+                if name.startswith(path_or_prefix):
+                    name = name[len(path_or_prefix):]
 
-            first_level_file_name = name.split("/")[0]
-            if first_level_file_name and first_level_file_name not in _list:
-                _list.add(first_level_file_name)
-                yield first_level_file_name
+                first_level_file_name = name.split("/")[0]
+                if first_level_file_name and \
+                        first_level_file_name not in _list:
+                    _list.add(first_level_file_name)
+                    yield first_level_file_name
 
     def set_base(self, base):
         Container.reset_base_handler(self, base)

--- a/chainerio/io.py
+++ b/chainerio/io.py
@@ -73,7 +73,8 @@ class IO(abc.ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def list(self, path_or_prefix: Optional[str] = None) -> Iterator:
+    def list(self, path_or_prefix: Optional[str] = None,
+             recursive=False) -> Iterator:
         raise NotImplementedError()
 
     @abstractmethod

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -66,6 +66,13 @@ class TestZipHandler(unittest.TestCase):
             self.assertIn(self.zipped_file_name, zip_list)
             self.assertNotIn("", zip_list)
 
+            zip_generator = handler.list(recursive=True)
+            zip_list = list(zip_generator)
+            self.assertIn(self.dir_name, zip_list)
+            self.assertIn(os.path.join(self.dir_name, self.zipped_file_name),
+                          zip_list)
+            self.assertNotIn("", zip_list)
+
     def test_info(self):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
             self.assertIsInstance(handler.info(), str)


### PR DESCRIPTION
This PR add recursive parameter to `list` API and implement `recursive in zip`.
This PR solves the first to-do in #46 and #43. 