### PR TITLE
Add recursive support to list in http

### DIFF
--- a/chainerio/filesystems/http.py
+++ b/chainerio/filesystems/http.py
@@ -36,7 +36,7 @@ class HttpFileSystem(FileSystem):
             info_str += ', the URL is {}'.format(self.url)
         return info_str
 
-    def list(self, path_or_prefix: str = None):
+    def list(self, path_or_prefix: str = None, recursive=False):
         raise io.UnsupportedOperation("http filesystem does not support list")
 
     def stat(self, path):


### PR DESCRIPTION
This PR adds recursive option to http, to align with the API.
This solves the 4th todo in #46 