### PR TITLE
Add doc strings to public API

### DIFF
--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -189,10 +189,15 @@ def set_root(uri_or_handler: Union[str, Type['IO']]) -> None:
     +=========+===========================+
     | POSIX   | current working directory |
     +---------+---------------------------+
-    | HDFS    |     /user/USERNAME        |
+    | HDFS    |     /user/``USERNAME`` #1 |
     +---------+---------------------------+
     | zip     |      top directory        |
     +---------+---------------------------+
+
+    #1 For the details about the ``USERNAME`` in HDFS, please refer to
+    `HDFS Document <https://hadoop.apache.org/docs/current/\
+            hadoop-project-dist/hadoop-hdfs/HdfsPermissionsGuide.html>`_
+
 
     Args:
         uri_or_handler (str or :class:~`chainerio.IO`): The ``uri_or_handler``

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -2,7 +2,7 @@ from chainerio._context import DefaultContext
 from chainerio.version import __version__  # NOQA
 
 from chainerio.io import IO
-from chainerio._typing import Optional
+from chainerio._typing import Optional, Union
 from typing import Iterator, Any, Callable, Type
 
 
@@ -10,6 +10,23 @@ _DEFAULT_CONTEXT = DefaultContext()
 
 
 def open_as_container(path: str) -> IO:
+    """Opens a container files and returns the handler
+
+    This function works similar to the :func:`open`,
+    while it opens a container, e.g. zip, instead of a regular file.
+
+    Args:
+        path (str): The path to the container. The path can be 
+        an Unix path or an URI.
+
+    Returns:
+        A container handler that implements methods defined in
+        :class:`chainerio.Container`, which derived from
+        :class:`chainerio.IO`. The type of the container is
+        determined by the extension of the given path.
+        Currently, only zip is supported.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
@@ -17,22 +34,24 @@ def open_as_container(path: str) -> IO:
 
 
 def list(path_or_prefix: Optional[str] = None,
-         recursive: bool = False) -> Iterator:
-    """list all the files under the given path_or_prefix
+         recursive: bool = False) -> Iterator[str]:
+    """Lists all the files and directories under the given ``path_or_prefix``
 
     Args:
-       path_or_prefix (str): The path to list against.
-           When we get the default value, list behave similar to
-           the default os.listdir: it shows the content under
-           the root directory, which is set to local $HOME,
-           as the default value.
-           Please note that the meaning of $HOME depends on each filesystem.
-           However, if a `path_or_prefix` is given,
-           then it shows all the files that start with `path_or_prefix`
+        path_or_prefix (str): The path to list against.
+            When we get the default value, ``list`` shows the content under
+            the root path, as the default value.
+            Refer to :func:`set_root` for details about the root path of
+            each filesystem. However, if a ``path_or_prefix`` is given,
+            then it shows only the files and directories
+            under the ``path_or_prefix``. The ``path_or_prefix`` can be an
+            Unix path or an URI.
 
-       recursive (bool): When set, list files and directories
-           recursively. Performance issues might occur for huge directories.
-           Mostly useful for containers such as zip.
+        recursive (bool): When this is ``True``, list files and directories
+            recursively.
+
+    Returns:
+        An Iterator that iterates though the files and directories.
 
     """
 
@@ -47,6 +66,14 @@ def list(path_or_prefix: Optional[str] = None,
 
 
 def info() -> str:
+    """Shows the detail of the current default handler
+
+    Please refer to the :func:`set_root` for details about the default handler.
+
+    Returns:
+        A string that describes the details of the default handler.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
@@ -60,6 +87,41 @@ def open(file_path: str, mode: str = 'rb',
          closefd: bool = True,
          opener: Optional[Callable[
              [str, int], Any]] = None) -> Type['IOBase']:
+    """Opens a regular file with ``mode``
+
+    If an Unix path is given, the method use the default handler,
+    and identifies the file from root path.
+    See :func:`set_root` for details about root path and default handler.
+    If an URI is given, the filesystem is chosen according to the given scheme.
+
+    The function returns a file object, and the type depends on
+    the filesystem of the file and ``mode``.
+    For HDFS, the return type is the same as the POSIX/built-in case.
+
+    Args:
+        file_path (str): the target file path, can be an Unix path,
+            or an URI.
+
+        mode (str): the open mode of the file. Currently, the 
+        following modes are supported:
+
+        +----+-----------------------+
+        |mode|      Meaning          |
+        +====+=======================+
+        | r  | read as a text file   |
+        +----+-----------------------+
+        | w  | write as a text file  |
+        +----+-----------------------+
+        | rb | read as a binary file |
+        +----+-----------------------+
+        | wb | write as a binary file|
+        +----+-----------------------+
+        
+
+    Returns:
+        A file object according to the filesystem and ``mode``.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
@@ -69,60 +131,202 @@ def open(file_path: str, mode: str = 'rb',
         errors, newline, closefd, opener)
 
 
-def set_root(uri_or_handler: str) -> None:
+def set_root(uri_or_handler: Union[str, Type['IO']]) -> None:
+    """Sets the current context to ``uri_or_handler``
+
+    The context here refers to the default handler and the root path.
+    The default handler points to a filesystem or a container which
+    ChainerIO uses when called without a full URI. Overrides by the full URI.
+    The default handler can be created by :func:`create_handler` with
+    the name of the handler.
+
+    Example::
+
+        # Case 1
+        # set_root by the name of uri 
+        chainerio.set_root("posix")
+        # open a file on posix filesystem with path "some/file"
+        chainerio.open("some/file")
+        # override with a full uri
+        chainerio.open("hdfs:///some/file/on/hdfs")
+
+        # Case 2
+        # set_root by uri
+        chainerio.set_root("hdfs:///some/directory")
+        # open a file "on/hdfs" on hdfs under the " some/directory"
+        chainerio.open("on/hdfs")
+
+        # Case 3
+        handler = chainerio.create_handler('hdfs')
+        # set_root by handler
+        chainerio.set_root(handler)
+        # open a file "/some/file/on/hdfs" on hdfs
+        chainerio.open("/some/file/on/hdfs")
+
+        # Case 4
+        handler = chainerio.open_as_container('some.zip')
+        # set_root by handler
+        chainerio.set_root(handler)
+        # open a file "img.jpg" in "some.zip"
+        chainerio.open("img.jpg")
+
+    The root path refers to a directory that ChainerIO works on.
+    It is similar to current working directory, ``CWD`` in terms of the shell
+    environment.
+    The root path will only be set
+    when the ``uri_or_handler`` points to a directory.
+    Otherwise, it will be set to default,
+    which represents the default working directory as follow:
+
+    +---------+---------------------------+
+    |         |     Default Root Path     |
+    +=========+===========================+
+    | POSIX   | current working directory |
+    +---------+---------------------------+
+    | HDFS    |     /user/USERNAME        |
+    +---------+---------------------------+
+    | zip     |      top directory        |
+    +---------+---------------------------+
+
+    Args:
+        uri_or_handler (str or :class:~`chainerio.IO`): The ``uri_or_handler``
+            can accept the following three kinds of values:
+
+            1. the name of a handler (string): set the default handler
+                to the corresponding handler, and root path.
+                See :func:`create_handler` for supported name of handlers.
+
+            2. an uri of directory (string): set the context
+                to use the corresponding handler and set
+                the root path to the given directory.
+
+            3. a handler, which is an instance of
+                :class:`chainerio.IO`. Set the default handler
+                to the given handler, and root path to default.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     default_context.set_root(uri_or_handler)
 
 
-def create_handler(uri: str) -> IO:
+def create_handler(handler_name: str) -> IO:
+    """Returns a handler according to the given ``handler_name``
+
+    The current supported handlers are:
+
+    1. posix
+    2. hdfs
+
+    Args:
+        handler_name (str): the name of handler to create
+
+    Returns:
+        An object of :class:`chainerio.IO`
+        according to the ``handler_name``
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(uri)
+        default_context.get_handler_by_name(handler_name)
     return handler
 
 
-def isdir(file_path: str) -> bool:
+def isdir(path: str) -> bool:
+    """Returns ``Ture`` if the path is an existing directory
+
+    Args:
+        path (str): the path to the target directory
+            The ``path`` can be an Unix path or an URI.
+
+    Returns:
+        ``True`` when the path points to a directory, ``False`` when it is not
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(file_path)
+        default_context.get_handler_by_name(path)
     return handler.isdir(actual_path)
 
 
-def mkdir(file_path: str, mode: int = 0o777, **kwargs) -> None:
+def mkdir(path: str, mode: int = 0o777, **kwargs) -> None:
+    """Makes a directory with mode
+
+    Args:
+        path (str): the path to the directory to make
+            The ``path`` can be an Unix path or an URI.
+
+        mode (int): the mode of the new directory
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(file_path)
+        default_context.get_handler_by_name(path)
     return handler.mkdir(actual_path, mode, *kwargs)
 
 
-def makedirs(file_path: str, mode: int = 0o777,
+def makedirs(path: str, mode: int = 0o777,
              exist_ok: bool = False) -> None:
+    """Makes directories recursively with mode
+
+    Also creates all the missing parents of the given path.
+
+    Args:
+        path (str): the path to the directory to make.
+            The ``path`` can be  an Unix path or an URI.
+
+        mode (int): the mode of the directory
+
+        exist_ok (bool): In default case, a `FileExitsError` will be raised
+            when the target directory exists. Set the ``exist_ok`` to surpass
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(file_path)
+        default_context.get_handler_by_name(path)
     return handler.makedirs(actual_path, mode, exist_ok)
 
 
-def exists(file_path: str) -> bool:
+def exists(path: str) -> bool:
+    """Returns ``True`` when the given ``path`` exists
+
+    Args:
+        path (str): the ``path`` to the target file. The ``path`` can be an
+        Unix path or an URI.
+
+    Returns:
+        ``True`` when the file or directory exists, ``False`` when it is not.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
     (handler, actual_path, is_URI) = \
-        default_context.get_handler_by_name(file_path)
+        default_context.get_handler_by_name(path)
     return handler.exists(actual_path)
 
 
 def rename(src: str, dst: str) -> None:
+    """Renames the file from ``src`` to ``dst``
+
+    Note the ``src`` and ``dst`` SHOULD be in the same filesystem.
+    The ``src`` and ``dst`` can be either Unix paths or URIs.
+
+    Args:
+        src (str): the current name of the target file or directory.
+
+        dst (str): the name to rename to.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
@@ -138,6 +342,20 @@ def rename(src: str, dst: str) -> None:
 
 
 def remove(path: str, recursive: bool = False) -> None:
+    """Removes a file or directory
+
+    A combination of :func:`os.remove` and :func:`os.rmtree`.
+
+    Args:
+        path (str): the target path to remove. The ``path`` can be a
+        regular file or a directory.
+        The ``path`` can be an Unix file path or an URI.
+
+        recursive (bool): When the given path is a directory, all the files
+            and directories under it will be removed.
+            When the path is a file, this option is ignored.
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
@@ -147,6 +365,12 @@ def remove(path: str, recursive: bool = False) -> None:
 
 
 def get_root_dir() -> str:
+    """get the current root path
+
+    Returns:
+        The current root path
+
+    """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -14,14 +14,21 @@ def open_as_container(path: str) -> IO:
 
     This function works similar to the :func:`open`,
     while it opens a container, e.g. zip, instead of a regular file.
+    For more details about the container, please refer to the `design \
+            <https://github.com/chainer/chainerio/blob/master/docs/\
+            source/design.rst#containers>`_
+
+    The function returns a handler to operate on the given container.
+    The handler is a object of :class:`chainerio.container.Container`,
+    which implements the APIs defines in the :class:`chainerio.IO`
 
     Args:
-        path (str): The path to the container. The path can be 
+        path (str): The path to the container. The path can be
         an Unix path or an URI.
 
     Returns:
         A container handler that implements methods defined in
-        :class:`chainerio.Container`, which derived from
+        :class:`chainerio.container.Container`, which derived from
         :class:`chainerio.IO`. The type of the container is
         determined by the extension of the given path.
         Currently, only zip is supported.
@@ -102,7 +109,7 @@ def open(file_path: str, mode: str = 'rb',
         file_path (str): the target file path, can be an Unix path,
             or an URI.
 
-        mode (str): the open mode of the file. Currently, the 
+        mode (str): the open mode of the file. Currently, the
         following modes are supported:
 
         +----+-----------------------+
@@ -116,7 +123,6 @@ def open(file_path: str, mode: str = 'rb',
         +----+-----------------------+
         | wb | write as a binary file|
         +----+-----------------------+
-        
 
     Returns:
         A file object according to the filesystem and ``mode``.
@@ -143,7 +149,7 @@ def set_root(uri_or_handler: Union[str, Type['IO']]) -> None:
     Example::
 
         # Case 1
-        # set_root by the name of uri 
+        # set_root by the name of uri
         chainerio.set_root("posix")
         # open a file on posix filesystem with path "some/file"
         chainerio.open("some/file")
@@ -254,7 +260,8 @@ def isdir(path: str) -> bool:
     return handler.isdir(actual_path)
 
 
-def mkdir(path: str, mode: int = 0o777, *, dir_fd: Optional[int] = None) -> None:
+def mkdir(path: str, mode: int = 0o777, *,
+          dir_fd: Optional[int] = None) -> None:
     """Makes a directory with mode
 
     Args:

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -15,7 +15,7 @@ def open_as_container(path: str) -> IO:
        Call the corresponding :func:`IO.open_as_container` upon the
        default handler.
 
-       The ``path`` can be  an Unix path or an URI.
+       The ``path`` can be a POSIX path or an URI.
 
     """
     global _DEFAULT_CONTEXT
@@ -30,7 +30,7 @@ def list(path_or_prefix: Optional[str] = None,
 
        Call the corresponding :func:`IO.list` upon the default handler.
 
-       The ``path`` can be  an Unix path or an URI.
+       The ``path`` can be a POSIX path or an URI.
 
     """
 
@@ -70,7 +70,7 @@ def open(file_path: str, mode: str = 'rb',
 
     Call the corresponding :func:`IO.open` upon the default handler.
 
-    If an Unix path is given, the method use the default handler,
+    If a POSIX path is given, the method use the default handler,
     and identifies the file from root path.
     See :func:`set_root` for details about root path and default handler.
     If an URI is given, right filesystem handler is automatically chosen
@@ -205,7 +205,7 @@ def isdir(path: str) -> bool:
 
     Call the corresponding :func:`IO.isdir` upon the default handler.
 
-    The ``path`` can be  an Unix path or an URI.
+    The ``path`` can be a POSIX path or an URI.
     """
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
@@ -221,7 +221,7 @@ def mkdir(path: str, mode: int = 0o777, *,
 
     Call the corresponding :func:`IO.mkdir` upon the default handler.
 
-    The ``path`` can be  an Unix path or an URI.
+    The ``path`` can be a POSIX path or an URI.
 
     """
     global _DEFAULT_CONTEXT
@@ -238,7 +238,7 @@ def makedirs(path: str, mode: int = 0o777,
 
     Call the corresponding :func:`IO.makedirs` upon the default handler.
 
-    The ``path`` can be  an Unix path or an URI.
+    The ``path`` can be a POSIX path or an URI.
 
     """
     global _DEFAULT_CONTEXT
@@ -254,7 +254,7 @@ def exists(path: str) -> bool:
 
     Call the corresponding :func:`IO.exists` upon the default handler.
 
-    The ``path`` can be an Unix path or an URI. or URIs.
+    The ``path`` can be a POSIX path or an URI. or URIs.
 
     """
     global _DEFAULT_CONTEXT
@@ -271,7 +271,7 @@ def rename(src: str, dst: str) -> None:
     Call the corresponding :func:`IO.rename` upon the default handler.
 
     Note the ``src`` and ``dst`` SHOULD be in the same filesystem.
-    The ``src`` and ``dst`` can be either Unix paths or URIs.
+    The ``src`` and ``dst`` can be either POSIX paths or URIs.
 
     """
     global _DEFAULT_CONTEXT
@@ -296,7 +296,7 @@ def remove(path: str, recursive: bool = False) -> None:
     Args:
         path (str): the target path to remove. The ``path`` can be a
         regular file or a directory.
-        The ``path`` can be an Unix file path or an URI.
+        The ``path`` can be a POSIX file path or an URI.
 
         recursive (bool): When the given path is a directory,
             all the files and directories under it will be removed.

--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -254,7 +254,7 @@ def isdir(path: str) -> bool:
     return handler.isdir(actual_path)
 
 
-def mkdir(path: str, mode: int = 0o777, **kwargs) -> None:
+def mkdir(path: str, mode: int = 0o777, *, dir_fd: Optional[int] = None) -> None:
     """Makes a directory with mode
 
     Args:
@@ -269,7 +269,7 @@ def mkdir(path: str, mode: int = 0o777, **kwargs) -> None:
 
     (handler, actual_path, is_URI) = \
         default_context.get_handler_by_name(path)
-    return handler.mkdir(actual_path, mode, *kwargs)
+    return handler.mkdir(actual_path, mode, dir_fd=dir_fd)
 
 
 def makedirs(path: str, mode: int = 0o777,

--- a/chainerio/io.py
+++ b/chainerio/io.py
@@ -59,6 +59,33 @@ class IO(abc.ABC):
              closefd: bool = True,
              opener: Optional[Callable[
                  [str, int], Any]] = None) -> Type["IOBase"]:
+        """Opens a regular file with ``mode``
+
+        The function returns a file object, and the type depends on
+        the filesystem of the file and ``mode``.
+
+        Args:
+            file_path (str): the target file path
+
+            mode (str): the open mode of the file. Currently, the
+            following modes are supported:
+
+            +----+-----------------------+
+            |mode|      Meaning          |
+            +====+=======================+
+            | r  | read as a text file   |
+            +----+-----------------------+
+            | w  | write as a text file  |
+            +----+-----------------------+
+            | rb | read as a binary file |
+            +----+-----------------------+
+            | wb | write as a binary file|
+            +----+-----------------------+
+
+        Returns:
+            A file object according to the ``mode``.
+
+        """
         raise NotImplementedError()
 
     @property
@@ -71,11 +98,36 @@ class IO(abc.ABC):
 
     @abstractmethod
     def info(self) -> str:
+        """Shows the detail of the current handler
+
+        Returns:
+        A string that describes the details of the default handler.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def list(self, path_or_prefix: Optional[str] = None,
-             recursive=False) -> Iterator:
+             recursive=False) -> Iterator[str]:
+        """Lists all the files and directories under
+           the given ``path_or_prefix``
+
+        Args:
+            path_or_prefix (str): The path to list against.
+                When we get the default value, ``list`` shows the content under
+                the root path, as the default value.
+                Refer to :func:`set_root` for details about the root path of
+                each filesystem. However, if a ``path_or_prefix`` is given,
+                then it shows only the files and directories
+                under the ``path_or_prefix``.
+
+            recursive (bool): When this is ``True``, list files and directories
+                recursively.
+
+        Returns:
+            An Iterator that iterates though the files and directories.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
@@ -100,38 +152,94 @@ class IO(abc.ABC):
 
     @abstractmethod
     def isdir(self, file_path: str) -> bool:
+        """Returns ``True`` if the path is an existing directory
+
+        Args:
+            path (str): the path to the target directory
+
+        Returns:
+            ``True`` when the path points to a directory,
+            ``False`` when it is not
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def mkdir(self, file_path: str, mode: int = 0o777,
               *args, dir_fd: Optional[int] = None) -> None:
+        """Makes a directory with mode
+
+        Args:
+            path (str): the path to the directory to make
+
+            mode (int): the mode of the new directory
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def makedirs(self, file_path: str, mode: int = 0o777,
                  exist_ok: bool = False) -> None:
+        """Makes directories recursively with mode
+
+        Also creates all the missing parents of the given path.
+
+        Args:
+            path (str): the path to the directory to make.
+
+            mode (int): the mode of the directory
+
+            exist_ok (bool): In default case, a ``FileExitsError`` will be
+                raised when the target directory exists.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def exists(self, file_path: str) -> bool:
+        """Returns ``True`` when the given ``path`` exists
+
+        When the ``file_path`` points to a symlink, the return value
+        depends on the actual file instead of the link itself.
+
+        Args:
+            path (str): the ``path`` to the target file. The ``path`` can be an
+            Unix path or an URI.
+
+        Returns:
+            ``True`` when the file or directory exists,
+            ``False`` when it is not.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def rename(self, src: str, dst: str) -> None:
+        """Renames the file from ``src`` to ``dst``
+
+        Args:
+            src (str): the current name of the file or directory.
+
+            dst (str): the name to rename to.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def remove(self, file_path: str, recursive: bool = False) -> None:
-        '''
-        Remove the file pointed by the file_path
+        """Removes a file or directory
 
-        Args:
-            file_path (str): file path to be removed.
-                          It can be a file or a directory.
-            recursive (boolean): When set, the remove deletes all the
-                          files and directories under the given file_path,
-                          includes the given file_path itself.
-        '''
+           A combination of :func:`os.remove` and :func:`os.rmtree`.
+
+           Args:
+               path (str): the target path to remove. The ``path`` can be a
+               regular file or a directory.
+
+               recursive (bool): When the given path is a directory,
+                   all the files and directories under it will be removed.
+                   When the path is a file, this option is ignored.
+
+        """
         raise NotImplementedError()
 
     # TODO(tianqi) need to be changed to annotaion when we bump the
@@ -145,6 +253,26 @@ class IO(abc.ABC):
     # TODO(tianqi) need to be changed to annotaion when we bump the
     # Python version to >=3.7
     def open_as_container(self, container_file: str) -> 'IO':
+        """Opens a container and returns the handler
+
+        This function opens a container, e.g. zip, instead of a regular file.
+        For more details about the container, please refer to the `design \
+                <https://github.com/chainer/chainerio/blob/master/docs/\
+                source/design.rst#containers>`_
+
+        Works when the current handler is also a container: nested container.
+
+        Args:
+            path (str): The path to the container.
+
+        Returns:
+            A container handler that implements methods defined in
+            :class:`chainerio.container.Container`, which derived from
+            :class:`chainerio.IO`. The type of the container is
+            determined by the extension of the given path.
+            Currently, only zip is supported.
+
+        """
         container_class = self._get_container_handler(container_file)
         return container_class(self, container_file)
 

--- a/chainerio/io.py
+++ b/chainerio/io.py
@@ -203,8 +203,8 @@ class IO(abc.ABC):
         depends on the actual file instead of the link itself.
 
         Args:
-            path (str): the ``path`` to the target file. The ``path`` can be an
-            Unix path or an URI.
+            path (str): the ``path`` to the target file. The ``path`` can be a
+            POSIX path or an URI.
 
         Returns:
             ``True`` when the file or directory exists,

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -23,6 +23,10 @@ Toplevel Functions
 
 .. autoclass:: IO
    :members:
+.. autoclass:: chainerio.filesystem.FileSystem
+   :members:
+.. autoclass:: chainerio.container.Container
+   :members:
 
 Cache API
 ---------


### PR DESCRIPTION
This commit adds doc strings to all the public APIs for chainerio
in `__init__.py`, which also is a superset of APIs in the `io.py`
This closes #55
This closes #52 