### PR TITLE
Use `klist` to get the username from kerberos

### DIFF
--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 
 
-def parse_klist_output(output):
+def _parse_klist_output(output):
     principle_str = output.decode('utf-8').split('\n')[1]
     klist_principal_pattern = re.compile(
         r'Default principal: (?P<username>.+)@(?P<service>.+)')
@@ -55,7 +55,7 @@ class HdfsFileSystem(FileSystem):
             if out == b'' and err != b'':
                 return None
             else:
-                return parse_klist_output(out)
+                return _parse_klist_output(out)
         except OSError:
             # klist is not found
             return None

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -1,7 +1,7 @@
 import unittest
 
 from collections.abc import Iterable
-from chainerio.filesystems.hdfs import parse_klist_output
+from chainerio.filesystems.hdfs import _parse_klist_output
 import pickle
 import shutil
 import os
@@ -63,7 +63,7 @@ class TestHdfsHandler(unittest.TestCase):
         service = 'fake_service!\"#$%&\'()*+,-./:;<=>?[\\]^ _`{|}~'
         correct_out = 'Ticket cache: FILE:/tmp/krb5cc_sdfa\nDefault principal: {}@{}\nValid starting       Expires              Service principal\n10/01/2019 12:44:18  10/08/2019 12:44:14   krbtgt/service@service\nrenew until 10/22/2019 15:04:20'.format(username, service) # NOQA
         self.assertEqual(username,
-                         parse_klist_output(correct_out.encode('utf-8')))
+                         _parse_klist_output(correct_out.encode('utf-8')))
 
     def test_list(self):
         with chainerio.create_handler(self.fs) as handler:


### PR DESCRIPTION
This PR changes to `klist` to get the default principal username from
the default keytab, instead of using the current login username, since
these two sometimes are different.

I have checked Python wrapper of kerberos like 
https://pypi.org/project/python-krbV/
https://pypi.org/project/kerberos/
they are either not maintained or does not support to get the username from keytab

This closes #50 