### PR TITLE
Support of directories without trailing slash in `stat` of zip

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -98,24 +98,18 @@ class ZipContainer(Container):
 
     def stat(self, path):
         self._open_zip_file()
-        try:
-            stat = self.zip_file_obj.getinfo(path)
-        except KeyError:
+        if path in self.zip_file_obj.namelist():
+            actual_path = path
+        elif (not path.endswith('/')
+              and path + '/' in self.zip_file_obj.namelist()):
             # handles cases when path is a directory but without trailing slash
             # see issue $67
-            if path.endswith('/'):
-                # the case where the file_path already has trailing slash
-                # and it is not in the zip, raise the KeyError
-                raise FileNotFoundError(
-                    "{} is not found".format(path))
-            else:
-                try:
-                    # retry with trailing slash
-                    stat = self.zip_file_obj.getinfo(path + '/')
-                except KeyError:
-                    raise FileNotFoundError(
-                        "{} is not found".format(path))
-        return stat
+            actual_path = path + '/'
+        else:
+            raise FileNotFoundError(
+                "{} is not found".format(path))
+
+        return self.zip_file_obj.getinfo(actual_path)
 
     def list(self, path_or_prefix: str = "", recursive=False):
         self._open_zip_file()

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -66,6 +66,9 @@ class TestZipHandler(unittest.TestCase):
         self.nested_zipped_file_path = os.path.join(
             self.nested_dir_name, self.nested_zipped_file_name)
 
+        self.non_exists_list = ["does_not_exist", "does_not_exist/",
+                                "does/not/exist"]
+
         os.mkdir(dir_path1)
         os.mkdir(dir_path2)
         os.mkdir(nested_dir_path)
@@ -254,6 +257,14 @@ class TestZipHandler(unittest.TestCase):
                     self.assertEqual(f.read(), self.nested_test_string)
 
     def test_stat(self):
-        # pass for now
-        # TODO(tianqi) add test after we well defined the stat
-        pass
+        with self.fs_handler.open_as_container(self.zip_file_path) as handler:
+            self.assertEqual(self.nested_zip_path,
+                             handler.stat(self.nested_zip_path).filename)
+
+            dir_list = [self.dir_name1, self.dir_name1.rstrip('/')]
+            for _dir in dir_list:
+                self.assertEqual(self.dir_name1, handler.stat(_dir).filename)
+
+            for _dir in self.non_exists_list:
+                with self.assertRaises(FileNotFoundError):
+                    handler.stat(_dir)


### PR DESCRIPTION
This commit adds non-trailing-slash support to directories to stat of
zip.
The code is mainly from the TODO in #68 
Solves Problem 2 in #67.