### PR TITLE
Support of directories without trailing slash in `exists` of zip 

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -140,8 +140,9 @@ class ZipContainer(Container):
 
     def exists(self, file_path: str):
         self._open_zip_file()
-        return (file_path in self.zip_file_obj.namelist()
-                or file_path + "/" in self.zip_file_obj.namelist())
+        namelist = self.zip_file_obj.namelist()
+        return (file_path in namelist
+                or file_path + "/" in namelist)
 
     def __enter__(self):
         return self

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -140,7 +140,8 @@ class ZipContainer(Container):
 
     def exists(self, file_path: str):
         self._open_zip_file()
-        return file_path in self.zip_file_obj.namelist()
+        return (file_path in self.zip_file_obj.namelist()
+                or file_path + "/" in self.zip_file_obj.namelist())
 
     def __enter__(self):
         return self

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -158,6 +158,9 @@ class TestZipHandler(unittest.TestCase):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
             self.assertTrue(handler.exists(self.dir_path))
             self.assertTrue(handler.exists(self.zipped_file_path))
+            dir_list = [self.dir_path, self.dir_path.rstrip('/')]
+            for _dir in dir_list:
+                self.assertTrue(handler.exists(_dir))
             self.assertFalse(handler.exists(non_exist_file))
 
     def test_remove(self):


### PR DESCRIPTION
This PR adds non-trailing-slash support to directories to `exists` of
zip.
Solves Problem 4 in #67.