### PR TITLE
Add Python 3.5.2 test to CI

### DIFF
--- a/.pfnci/docker/Dockerfile
+++ b/.pfnci/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 LABEL maintainer="tianqi@preferred.jp"
 
@@ -7,10 +7,8 @@ RUN apt-get update && \
     libreadline-dev wget python-openssl git ca-certificates && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ cmake make libffi-dev
+RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ cmake make libffi-dev patch
 
 COPY install.sh /tmp/install.sh
 
 RUN bash -c /tmp/install.sh
-
-RUN apt-get remove -y gcc g++ cmake libreadline-dev python-openssl && apt-get -y autoremove

--- a/.pfnci/docker/install.sh
+++ b/.pfnci/docker/install.sh
@@ -4,13 +4,12 @@ function install_py()
 {
     PYTHON_VERSION=$1
     PYENV_ROOT=$2
-    CFLAGS=-I/usr/include/openssl
-    LDFLAGS=-L/usr/lib pyenv install $PYTHON_VERSION
+    pyenv install $PYTHON_VERSION
     pyenv shell $PYTHON_VERSION
     pyenv global $PYTHON_VERSION
 }
 
-python_versions=('3.5.7' '3.6.8' '3.7.2')
+python_versions=('3.5.2' '3.5.7' '3.6.8' '3.7.2')
 PYENV_ROOT=/root/.pyenv
 
 rm -rf $PYENV_ROOT

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -2,7 +2,7 @@
 set -eux
 
 source /root/.bash_docker
-pyenv global 3.5.7 3.6.8 3.7.2
+pyenv global 3.5.2 3.6.8 3.7.2
 tox && :
 tox_status=$?
 pip install .[doc]


### PR DESCRIPTION
Add Python 3.5.2 test into docker and test script. The Python 3.5.2 replaces the 3.5.8 test as tox does not support specifying micro version. 
Downgrade the base docker image from ubuntu:18.04 to ubuntu:16.04
as 18.04 only support openssl 1.1.0 which does not work with Python
3.5.2.

This closes #74 