### PR TITLE
Avoid make_archive in the test_zip_container

### DIFF
--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -55,7 +55,7 @@ class TestZipHandler(unittest.TestCase):
         nested_zipped_file_path = os.path.join(
             nested_dir_path, self.nested_zipped_file_name)
         nested_zip_file_path = os.path.join(
-            dir_path1, self.nested_zipped_file_name)
+            dir_path1, self.nested_zip_file_name)
 
         # paths used in tests
         self.zip_file_path = self.zip_file_name + ".zip"
@@ -82,14 +82,28 @@ class TestZipHandler(unittest.TestCase):
         with open(testfile_path, "w") as tmpfile:
             tmpfile.write(self.test_string)
 
-        shutil.make_archive(nested_zip_file_path, "zip",
-                            root_dir=self.tmpdir.name,
-                            base_dir=self.nested_dir_name)
+        self.make_archive(nested_zip_file_path,
+                          root_dir=self.tmpdir.name,
+                          base_dir=self.nested_dir_name)
         shutil.rmtree(nested_dir_path)
 
         # this will include outside.zip itself into the zip
-        shutil.make_archive(self.zip_file_name, "zip",
-                            root_dir=self.tmpdir.name)
+        self.make_archive(self.zip_file_path,
+                          root_dir=self.tmpdir.name,
+                          base_dir=".")
+
+    def make_archive(self, zipfilename, root_dir, base_dir):
+        pwd = os.getcwd()
+        with ZipFile(zipfilename, "w") as f:
+            os.chdir(root_dir)
+            for root, dirs, filenames in os.walk(base_dir):
+                for _dir in dirs:
+                    path = os.path.normpath(os.path.join(root, _dir))
+                    f.write(path)
+                for _file in filenames:
+                    path = os.path.normpath(os.path.join(root, _file))
+                    f.write(path)
+            os.chdir(pwd)
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -8,6 +8,19 @@ import shutil
 import tempfile
 from zipfile import ZipFile
 
+def make_zip(zipfilename, root_dir, base_dir):
+    pwd = os.getcwd()
+    with ZipFile(zipfilename, "w") as f:
+        os.chdir(root_dir)
+        for root, dirs, filenames in os.walk(base_dir):
+            for _dir in dirs:
+                path = os.path.normpath(os.path.join(root, _dir))
+                f.write(path)
+            for _file in filenames:
+                path = os.path.normpath(os.path.join(root, _file))
+                f.write(path)
+        os.chdir(pwd)
+
 
 class TestZipHandler(unittest.TestCase):
 
@@ -82,28 +95,15 @@ class TestZipHandler(unittest.TestCase):
         with open(testfile_path, "w") as tmpfile:
             tmpfile.write(self.test_string)
 
-        self.make_archive(nested_zip_file_path,
-                          root_dir=self.tmpdir.name,
-                          base_dir=self.nested_dir_name)
+        make_zip(nested_zip_file_path,
+                 root_dir=self.tmpdir.name,
+                 base_dir=self.nested_dir_name)
         shutil.rmtree(nested_dir_path)
 
         # this will include outside.zip itself into the zip
-        self.make_archive(self.zip_file_path,
-                          root_dir=self.tmpdir.name,
-                          base_dir=".")
-
-    def make_archive(self, zipfilename, root_dir, base_dir):
-        pwd = os.getcwd()
-        with ZipFile(zipfilename, "w") as f:
-            os.chdir(root_dir)
-            for root, dirs, filenames in os.walk(base_dir):
-                for _dir in dirs:
-                    path = os.path.normpath(os.path.join(root, _dir))
-                    f.write(path)
-                for _file in filenames:
-                    path = os.path.normpath(os.path.join(root, _file))
-                    f.write(path)
-            os.chdir(pwd)
+        make_zip(self.zip_file_path,
+                 root_dir=self.tmpdir.name,
+                 base_dir=".")
 
     def tearDown(self):
         self.tmpdir.cleanup()

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 from zipfile import ZipFile
 
+
 def make_zip(zipfilename, root_dir, base_dir):
     pwd = os.getcwd()
     with ZipFile(zipfilename, "w") as f:


### PR DESCRIPTION
We avoid using `shutil.make_archive` to create the test zip file as the
`shutil.make_archive` introduced an inconsistent behavior between versions
when creating the zip file. For more details, please refer to
https://bugs.python.org/issue28488

In this PR, we switch our own make_zip to create the zip.