### PR TITLE
Fix a bug in test_zip_container

### DIFF
--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -309,7 +309,7 @@ class TestZipHandler(unittest.TestCase):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
             self.assertTrue(handler.exists(self.dir_name1))
             self.assertTrue(handler.exists(self.zipped_file_path))
-            dir_list = [self.dir_path, self.dir_path.rstrip('/')]
+            dir_list = [self.dir_name1, self.dir_name1.rstrip('/')]
             for _dir in dir_list:
                 self.assertTrue(handler.exists(_dir))
             self.assertFalse(handler.exists(non_exist_file))


### PR DESCRIPTION
This commit fixes a bug caused by a outdated variable name in
test_zip_container.