### PR TITLE
Normalize input path in zip `stat`

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -97,6 +97,7 @@ class ZipContainer(Container):
         return info_str
 
     def stat(self, path):
+        path = os.path.normpath(path)
         self._open_zip_file()
         if path in self.zip_file_obj.namelist():
             actual_path = path


### PR DESCRIPTION
This PR normalizes the input path first before any process in zip `stat`.
This PR solves a part of issue #75.