### PR TITLE
Normalize input path in zip `isdir`

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -127,9 +127,13 @@ class ZipContainer(Container):
         else:
             given_dir_list = []
 
-        if path_or_prefix and not self.isdir(path_or_prefix):
-            raise NotADirectoryError(
-                "{} is not a directory".format(path_or_prefix))
+        if path_or_prefix:
+            if not self.exists(path_or_prefix):
+                raise FileNotFoundError(
+                    "{} is not found".format(path_or_prefix))
+            elif not self.isdir(path_or_prefix):
+                raise NotADirectoryError(
+                    "{} is not a directory".format(path_or_prefix))
 
         if recursive:
             for name in self.zip_file_obj.namelist():
@@ -166,11 +170,14 @@ class ZipContainer(Container):
             self.zip_file_obj = None
 
     def isdir(self, file_path: str):
-        stat = self.stat(file_path)
-        # The `is_dir` function under `ZipInfo` object
-        # is not available on my testbed
-        # Copied the code from the `zipfile.py`
-        return "/" == stat.filename[-1]
+        if self.exists(file_path):
+            stat = self.stat(file_path)
+            # The `is_dir` function under `ZipInfo` object
+            # is not available on my testbed
+            # Copied the code from the `zipfile.py`
+            return "/" == stat.filename[-1]
+        else:
+            return False
 
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):
         raise io.UnsupportedOperation("zip does not support mkdir")

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -172,10 +172,12 @@ class ZipContainer(Container):
     def isdir(self, file_path: str):
         if self.exists(file_path):
             stat = self.stat(file_path)
-            # The `is_dir` function under `ZipInfo` object
-            # is not available on my testbed
-            # Copied the code from the `zipfile.py`
-            return "/" == stat.filename[-1]
+            if sys.version_info >= (3, 6, ):
+                return stat.is_dir()
+            else:
+                # The `is_dir` function under `ZipInfo` object
+                # is not available before Python 3.6.0
+                return "/" == stat.filename[-1]
         else:
             return False
 

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -281,14 +281,40 @@ class TestZipHandler(unittest.TestCase):
             self.assertIsInstance(handler.info(), str)
 
     def test_isdir(self):
+        cases = [
+            # path ends with slash
+            {"path_or_prefix": 'testdir2//',
+             "expected": True},
+            # not normalized path
+            {"path_or_prefix": 'testdir2//testfile1',
+             "expected": False},
+            {"path_or_prefix": 'testdir1//..//testdir2/testfile1',
+             "expected": False},
+            # problem 2 in issue #66
+            {"path_or_prefix": self.dir_name2.rstrip('/'),
+             "expected": True},
+            # not normalized path
+            {"path_or_prefix": 'testdir2//testfile1//../',
+             "expected": True},
+            # not normalized path root
+            {"path_or_prefix": 'testdir2//..//',
+             "expected": False},
+            # not normalized path beyond root
+            {"path_or_prefix": '//..//',
+             "expected": False},
+            # not normalized path beyond root
+            {"path_or_prefix": 'testdir2//..//',
+             "expected": False},
+            # starting with slash
+            {"path_or_prefix": '/',
+             "expected": False}]
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
-            self.assertTrue(handler.isdir(self.dir_name1))
-            self.assertTrue(handler.isdir(self.dir_name1.rstrip('/')))
-            self.assertFalse(handler.isdir(self.zipped_file_path))
-            self.assertFalse(handler.isdir(self.zipped_file_path.rstrip('/')))
+            for case in cases:
+                self.assertEqual(handler.isdir(case["path_or_prefix"]),
+                                 case["expected"])
+
             for _dir in self.non_exists_list:
-                with self.assertRaises(FileNotFoundError):
-                    handler.isdir(_dir)
+                self.assertFalse(handler.isdir(_dir))
 
     def test_mkdir(self):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:


### PR DESCRIPTION
The `isdir` simply forwards the input to `stat` and relies on `stat`
to normalize the input path.
To align with the behavior of `os.path.isdir`, False is returned when
the given file or directory does not exist.