### PR TITLE
Normalize input path in zip `open`

### DIFF
--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -81,6 +81,7 @@ class ZipContainer(Container):
              buffering=-1, encoding=None, errors=None,
              newline=None, closefd=True, opener=None):
 
+        file_path = os.path.normpath(file_path)
         self._open_zip_file(mode)
 
         # zip only supports open with r rU or U

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -129,6 +129,17 @@ class TestZipHandler(unittest.TestCase):
         with self.fs_handler.open_as_container(non_exist_file) as handler:
             self.assertRaises(IOError, handler.open, non_exist_file)
 
+    def test_open_non_normalized_path(self):
+        cases = [
+            # not normalized path
+            {"path_or_prefix": '././testdir2//../testdir2/testfile1',
+             "expected": self.test_string}]
+        for case in cases:
+            with self.fs_handler.open_as_container(
+                    os.path.abspath(self.zip_file_path)) as handler:
+                with handler.open(case['path_or_prefix'], "r") as zipped_file:
+                    self.assertEqual(case['expected'], zipped_file.read())
+
     def test_list(self):
         with self.fs_handler.open_as_container(self.zip_file_path) as handler:
             cases = [


### PR DESCRIPTION
This PR normalizes the input path first before any process in zip
open.
This PR solves a part of issue #75.