### PR TITLE
Check for the supported scheme in `create_handler`

### DIFF
--- a/chainerio/__init__.py
+++ b/chainerio/__init__.py
@@ -195,6 +195,9 @@ def create_handler(scheme: str) -> IO:
     global _DEFAULT_CONTEXT
     default_context = _DEFAULT_CONTEXT
 
+    if not default_context.is_supported_scheme(scheme):
+        raise ValueError("scheme {} is not supported".format(scheme))
+
     (handler, actual_path, is_URI) = \
         default_context.get_handler_by_name(scheme)
     return handler

--- a/chainerio/_context.py
+++ b/chainerio/_context.py
@@ -12,6 +12,9 @@ class FileSystemDriverList(object):
     def __init__(self):
         self._handler_dict = {}
 
+        # TODO(tianqi): dynamically create this list
+        # as well as the patterns upon loading the chainerio module.
+        self.scheme_list = ["hdfs", "posix"]
         self.posix_pattern = re.compile(r"file:\/\/(?P<path>.+)")
         self.hdfs_pattern = re.compile(r"(?P<path>hdfs:\/\/.+)")
         self.pattern_list = {"hdfs": self.hdfs_pattern,
@@ -61,6 +64,9 @@ class FileSystemDriverList(object):
                 uri_or_handler_name)
             new_handler.root = actual_path
             return (new_handler, actual_path, is_URI)
+
+    def is_supported_scheme(self, scheme: str) -> bool:
+        return scheme in self.scheme_list
 
 
 class DefaultContext(object):
@@ -115,3 +121,6 @@ class DefaultContext(object):
 
     def get_root_dir(self) -> str:
         return self._root
+
+    def is_supported_scheme(self, scheme: str) -> bool:
+        return self._fs_handler_list.is_supported_scheme(scheme)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -156,6 +156,18 @@ class TestContext(unittest.TestCase):
         conn.delete(hdfs_tmpfile)
         conn.close()
 
+    def test_create_handler(self):
+        posix_handler = chainerio.create_handler("posix")
+        self.assertIsInstance(posix_handler,
+                              chainerio.filesystems.posix.PosixFileSystem)
+
+        hdfs_handler = chainerio.create_handler("hdfs")
+        self.assertIsInstance(hdfs_handler,
+                              chainerio.filesystems.hdfs.HdfsFileSystem)
+
+        with self.assertRaises(ValueError):
+            chainerio.create_handler("unsupported_scheme")
+
     def test_list(self):
         nested_dir_name1 = "nested_dir1"
         nested_dir_name2 = "nested_dir2"


### PR DESCRIPTION
This PR add scheme checks to the beginning of `create_handler`, and
raises ValueError when the scheme is not supported.
This PR closes #86.