### PR TITLE
Add persistence to cache.FileCache

### DIFF
--- a/chainerio/cache/file_cache.py
+++ b/chainerio/cache/file_cache.py
@@ -262,7 +262,7 @@ class FileCache(cache.Cache):
         After loading the files, no data can be added to the cache.
         ``name`` is the prefix of the persistent files. To use cache
         in ``multiprocessing`` environment, call this method at every
-        forked process.
+        forked process, except the process that called ``preserve()``.
 
         .. note:: This feature is experimental.
 
@@ -283,9 +283,9 @@ class FileCache(cache.Cache):
             self._frozen = True
 
     def preserve(self, name):
-        '''Preserve the cache as persistent files in the disk
+        '''Preserve the cache as persistent files on the disk
 
-        Once the cache is preserved, cache files are not to be removed
+        Once the cache is preserved, cache files will not be removed
         at cache close. To read data from preserved files, use
         ``preload()`` method. After preservation, no data can be added
         to the cache.  ``name`` is the prefix of the persistent

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -40,7 +40,7 @@ Cache API
    :members:
 
 .. autoclass:: FileCache
-   :members:
+   :members: preserve, preload
 
 Chainer Extensions API
 ----------------------

--- a/tests/cache_tests/test_file_cache.py
+++ b/tests/cache_tests/test_file_cache.py
@@ -1,5 +1,6 @@
 from chainerio.cache import FileCache
 import os
+import tempfile
 
 import pytest
 
@@ -28,3 +29,25 @@ def test_enoent(monkeypatch):
 
             with pytest.raises(OSError):
                 cache.put(4, str(4))
+
+
+def test_preservation():
+    with tempfile.TemporaryDirectory() as d:
+        cache = FileCache(10, dir=d, do_pickle=True)
+
+        for i in range(10):
+            cache.put(i, str(i))
+
+        cache.preserve('preserved')
+
+        for i in range(10):
+            assert str(i) == cache.get(i)
+
+        cache.close()
+
+        # Imitating a new process, fresh load
+        cache2 = FileCache(10, dir=d, do_pickle=True)
+
+        cache2.preload('preserved')
+        for i in range(10):
+            assert str(i) == cache2.get(i)


### PR DESCRIPTION
By letting developers explicitly call `perserve()` method, the cache knows when to freeze the data. This change resolve the issue that cached data can't be reused across the training session (thus re-constructing the cache by re-reading data from remote storage), limiting the use cases to only same number & configuration of cached data.

See `tests/cache_tests/test_file_cache.py` for possible example usage.
