### PR TITLE
Move to krbticket 1.0.2

### DIFF
--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -72,7 +72,7 @@ class HdfsFileSystem(FileSystem):
             # variable. If /etc/krb5.keytab doesn't exist, krbticket
             # tries to update the ticket with ``kinit -R`` as much as
             # possible.
-            self.ticket = KrbTicket.init(self.username)
+            self.ticket = KrbTicket.get_or_init(self.username)
             self.ticket.updater_start()
 
             connection = hdfs.connect()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.5",
-    install_requires=['krbticket>=1.0.1', 'pyarrow'],
+    install_requires=['krbticket>=1.0.2', 'pyarrow'],
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
This commit changes to use krbticket 1.0.2 to avoid issues when the
KRB5_KTNAME is not given.
This PR should be tested after #95 