### PR TITLE
Update to krbticket 1.0.3

### DIFF
--- a/chainerio/filesystems/hdfs.py
+++ b/chainerio/filesystems/hdfs.py
@@ -1,6 +1,6 @@
 from chainerio.filesystem import FileSystem
 from chainerio.io import open_wrapper
-from krbticket import KrbTicket
+from krbticket import KrbTicket, SingleProcessKrbTicketUpdater
 
 import subprocess
 import re
@@ -118,7 +118,8 @@ class HdfsFileSystem(FileSystem):
             # variable. If /etc/krb5.keytab doesn't exist, krbticket
             # tries to update the ticket with ``kinit -R`` as much as
             # possible.
-            self.ticket = KrbTicket.get_or_init(self.username)
+            self.ticket = KrbTicket.get_or_init(
+                self.username, updater_class=SingleProcessKrbTicketUpdater)
             self.ticket.updater_start()
 
             connection = hdfs.connect()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require={'test': ['pytest', 'flake8', 'autopep8'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.5",
-    install_requires=['krbticket>=1.0.2', 'pyarrow'],
+    install_requires=['krbticket>=1.0.3', 'pyarrow'],
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
To avoid kerberos ticket name issues when using multiprocessing.