### PR TITLE
Fix HDFS unittests

### DIFF
--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -259,28 +259,30 @@ class TestHdfsHandlerWithFile(unittest.TestCase):
                 nested_file = os.path.join(nested_dir2,  nested_file_name)
                 nested_file_relative = os.path.join(nested_dir_name2,
                                                     nested_file_name)
-                handler.makedirs(nested_dir1)
-                handler.makedirs(nested_dir2)
 
-                with handler.open(nested_file, "w") as f:
-                    f.write(self.test_string)
+                try:
+                    handler.makedirs(nested_dir1)
+                    handler.makedirs(nested_dir2)
 
-                recursive_file_generator = handler.list(test_dir_name,
-                                                        recursive=True)
-                self.assertIsInstance(recursive_file_generator, Iterable)
-                file_list = list(recursive_file_generator)
-                self.assertIn(nested_dir_name1, file_list)
-                self.assertIn(nested_dir_name2, file_list)
-                self.assertIn(nested_file_relative, file_list)
+                    with handler.open(nested_file, "w") as f:
+                        f.write(self.test_string)
 
-                normal_file_generator = handler.list(test_dir_name)
-                self.assertIsInstance(recursive_file_generator, Iterable)
-                file_list = list(normal_file_generator)
-                self.assertIn(nested_dir_name1, file_list)
-                self.assertIn(nested_dir_name2, file_list)
-                self.assertNotIn(nested_file_relative, file_list)
+                    recursive_file_generator = handler.list(test_dir_name,
+                                                            recursive=True)
+                    self.assertIsInstance(recursive_file_generator, Iterable)
+                    file_list = list(recursive_file_generator)
+                    self.assertIn(nested_dir_name1, file_list)
+                    self.assertIn(nested_dir_name2, file_list)
+                    self.assertIn(nested_file_relative, file_list)
 
-                handler.remove(test_dir_name, True)
+                    normal_file_generator = handler.list(test_dir_name)
+                    self.assertIsInstance(recursive_file_generator, Iterable)
+                    file_list = list(normal_file_generator)
+                    self.assertIn(nested_dir_name1, file_list)
+                    self.assertIn(nested_dir_name2, file_list)
+                    self.assertNotIn(nested_file_relative, file_list)
+                finally:
+                    handler.remove(test_dir_name, True)
 
     def test_isdir(self):
         with chainerio.create_handler(self.fs) as handler:

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -223,7 +223,7 @@ class TestHdfsHandlerWithFile(unittest.TestCase):
         self.tmpfile_name = "tmpfile.txt"
 
         with chainerio.create_handler(self.fs) as handler:
-            with handler.open(self.tmpfile_name, "wb") as tmpfile:
+            with handler.open(self.tmpfile_name, "w") as tmpfile:
                 tmpfile.write(self.test_string)
 
     def tearDown(self):

--- a/tests/filesystem_tests/test_hdfs_handler.py
+++ b/tests/filesystem_tests/test_hdfs_handler.py
@@ -37,6 +37,14 @@ class TestHdfsHandler(unittest.TestCase):
         self.fs = "hdfs"
         self.tmpfile_name = "tmpfile.txt"
 
+    def tearDown(self):
+
+        with chainerio.create_handler(self.fs) as handler:
+            try:
+                handler.remove(self.tmpfile_name)
+            except IOError:
+                pass
+
     def test_read_bytes(self):
 
         with chainerio.create_handler(self.fs) as handler:
@@ -148,6 +156,9 @@ class TestHdfsHandler(unittest.TestCase):
 
     def test_list(self):
         with chainerio.create_handler(self.fs) as handler:
+            with handler.open(self.tmpfile_name, "w") as tmpfile:
+                tmpfile.write(self.test_string)
+
             file_generator = handler.list()
             self.assertIsInstance(file_generator, Iterable)
             file_list = list(file_generator)
@@ -194,6 +205,9 @@ class TestHdfsHandler(unittest.TestCase):
 
     def test_isdir(self):
         with chainerio.create_handler(self.fs) as handler:
+            with handler.open(self.tmpfile_name, "w") as tmpfile:
+                tmpfile.write(self.test_string)
+
             self.assertTrue(handler.isdir("/"))
             self.assertFalse(handler.isdir(self.tmpfile_name))
 
@@ -234,6 +248,9 @@ class TestHdfsHandler(unittest.TestCase):
         non_exist_file = "non_exist_file.txt"
 
         with chainerio.create_handler(self.fs) as handler:
+            with handler.open(self.tmpfile_name, "w") as tmpfile:
+                tmpfile.write(self.test_string)
+
             self.assertTrue(handler.exists(self.tmpfile_name))
             self.assertTrue(handler.exists("/"))
             self.assertFalse(handler.exists(non_exist_file))


### PR DESCRIPTION
This PR fixes HDFS unittests.


The following error occurred on the current master branch.
```
================================================================================================================ FAILURES ================================================================================================================
______________________________________________________________________________________________________ TestHdfsHandler.test_exists _______________________________________________________________________________________________________

self = <test_hdfs_handler.TestHdfsHandler testMethod=test_exists>

    def test_exists(self):
        non_exist_file = "non_exist_file.txt"
    
        with chainerio.create_handler(self.fs) as handler:
>           self.assertTrue(handler.exists(self.tmpfile_name))
E           AssertionError: False is not true

tests/filesystem_tests/test_hdfs_handler.py:237: AssertionError
_______________________________________________________________________________________________________ TestHdfsHandler.test_isdir _______________________________________________________________________________________________________

self = <test_hdfs_handler.TestHdfsHandler testMethod=test_isdir>

    def test_isdir(self):
        with chainerio.create_handler(self.fs) as handler:
            self.assertTrue(handler.isdir("/"))
>           self.assertFalse(handler.isdir(self.tmpfile_name))

tests/filesystem_tests/test_hdfs_handler.py:198: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
chainerio/filesystems/hdfs.py:238: in isdir
    stat = self.stat(file_path)
chainerio/filesystems/hdfs.py:224: in stat
    return self.connection.stat(path)
pyarrow/io-hdfs.pxi:247: in pyarrow.lib.HadoopFileSystem.stat
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   pyarrow.lib.ArrowIOError: Calling GetPathInfo for tmpfile.txt failed. errno: 2 (No such file or directory)

pyarrow/error.pxi:80: ArrowIOError
_______________________________________________________________________________________________________ TestHdfsHandler.test_list ________________________________________________________________________________________________________

self = <test_hdfs_handler.TestHdfsHandler testMethod=test_list>

    def test_list(self):
        with chainerio.create_handler(self.fs) as handler:
            file_generator = handler.list()
            self.assertIsInstance(file_generator, Iterable)
            file_list = list(file_generator)
>           self.assertIn(self.tmpfile_name, file_list, self.tmpfile_name)
E           AssertionError: 'tmpfile.txt' not found in ['.Trash'] : tmpfile.txt

tests/filesystem_tests/test_hdfs_handler.py:154: AssertionError
===================================================================================================== 3 failed, 13 passed in 13.99s ======================================================================================================
```

This PR solves these failures.