### PR TITLE
Bugfix: list and isdir for non-directory-included zip

### DIFF
--- a/.pfnci/docker/Dockerfile
+++ b/.pfnci/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="tianqi@preferred.jp"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev wget python-openssl git ca-certificates && \
+    libreadline-dev wget python-openssl git ca-certificates zip && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN apt-get update && apt-get install -y --no-install-recommends gcc g++ cmake make libffi-dev patch

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -145,12 +145,16 @@ class ZipContainer(Container):
             given_dir_list = []
 
         if path_or_prefix:
-            if not self.exists(path_or_prefix):
+            if self.exists(path_or_prefix):
+                if not self.isdir(path_or_prefix):
+                    raise NotADirectoryError(
+                        "{} is not a directory".format(path_or_prefix))
+            # check if directories are NOT included in the zip
+            # such kind of zip can be made with "zip -D"
+            elif not any(name.startswith(path_or_prefix + "/")
+                         for name in self.zip_file_obj.namelist()):
                 raise FileNotFoundError(
                     "{} is not found".format(path_or_prefix))
-            elif not self.isdir(path_or_prefix):
-                raise NotADirectoryError(
-                    "{} is not a directory".format(path_or_prefix))
 
         if recursive:
             for name in self.zip_file_obj.namelist():

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -145,14 +145,13 @@ class ZipContainer(Container):
             given_dir_list = []
 
         if path_or_prefix:
-            if self.exists(path_or_prefix):
-                if not self.isdir(path_or_prefix):
-                    raise NotADirectoryError(
-                        "{} is not a directory".format(path_or_prefix))
-            # check if directories are NOT included in the zip
-            # such kind of zip can be made with "zip -D"
+            if self.exists(path_or_prefix) and not self.isdir(path_or_prefix):
+                raise NotADirectoryError(
+                    "{} is not a directory".format(path_or_prefix))
             elif not any(name.startswith(path_or_prefix + "/")
                          for name in self.zip_file_obj.namelist()):
+                # check if directories are NOT included in the zip
+                # such kind of zip can be made with "zip -D"
                 raise FileNotFoundError(
                     "{} is not found".format(path_or_prefix))
 

--- a/chainerio/containers/zip.py
+++ b/chainerio/containers/zip.py
@@ -200,6 +200,12 @@ class ZipContainer(Container):
                 # is not available before Python 3.6.0
                 return "/" == stat.filename[-1]
         else:
+            file_path = os.path.normpath(file_path)
+            # check if directories are NOT included in the zip
+            if any(name.startswith(file_path + "/")
+                   for name in self.zip_file_obj.namelist()):
+                return True
+
             return False
 
     def mkdir(self, file_path: str, mode=0o777, *args, dir_fd=None):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     package_data={'chainerio': package_data},
-    extras_require={'test': ['pytest', 'flake8', 'autopep8'],
+    extras_require={'test': ['pytest', 'flake8', 'autopep8', 'parameterized'],
                     'doc': ['sphinx', 'sphinx_rtd_theme']},
     python_requires=">=3.5",
     install_requires=['krbticket>=1.0.3', 'pyarrow'],

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -655,12 +655,13 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
          [NO_DIRECTORY_FILENAME_LIST["testfile2_name"]],
          False],
         # not normalized path
-        ['testdir1//testfile//../',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//\
+           {NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
          False],
         # not normalized path root
-        ['testdir1//..//',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//',
          [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir3_name"],
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
@@ -672,7 +673,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
          False],
         # not normalized path beyond root
-        ['testdir1//..//',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//',
          [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir3_name"],
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
@@ -705,13 +706,13 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
          True],
         # not normalized path
-        ['testdir1//testfile//../',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../', # NOQA
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
          True],
         # not normalized path root
-        ['testdir2//..//',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}//..//',
          [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
@@ -733,7 +734,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
          True],
         # not normalized path beyond root
-        ['testdir2//..//',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}//..//../',
          [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
@@ -769,11 +770,12 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
         # not exist but share the prefix
         ['t', FileNotFoundError],
         # broken path
-        ['testdir1//t/', FileNotFoundError],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//t/', FileNotFoundError],
         # list a file
-        ['testdir1//testfile1///', NotADirectoryError],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}///', # NOQA
+         NotADirectoryError],
         # list a non_exist_dir but share the surfix
-        ['testdir/', FileNotFoundError]
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}[:-1]/', FileNotFoundError]
     ])
     def test_list_with_errors(self, path_or_prefix, error):
         with self.fs_handler.open_as_container(self.zip_file_name) as handler:
@@ -785,20 +787,23 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
 
     @parameterized.expand([
         # path ends with slash
-        ['testdir1//', True],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//', True],
         # not normalized path
-        ['testdir1//testfile1', False],
-        ['testdir1//..//testdir2/testfile1', False],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}', # NOQA
+            False],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}/{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}', # NOQA
+            False],
         # problem 2 in issue #66
         [NO_DIRECTORY_FILENAME_LIST["dir1_name"], True],
         # not normalized path
-        ['testdir1//testfile1//../', True],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../', # NOQA
+            True],
         # not normalized path root
-        ['testdir1//..//', False],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//', False],
         # not normalized path beyond root
         ['//..//', False],
         # not normalized path beyond root
-        ['testdir1//..//', False],
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//', False],
         # starting with slash
         ['/', False]
     ])

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -655,12 +655,13 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
          [NO_DIRECTORY_FILENAME_LIST["testfile2_name"]],
          False],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
+        ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
          False],
         # not normalized path root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//',
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
          [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir3_name"],
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
@@ -672,7 +673,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
          False],
         # not normalized path beyond root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//',
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
          [NO_DIRECTORY_FILENAME_LIST["dir1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir3_name"],
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
@@ -705,13 +706,15 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
          True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
+        ['{}//{}//../'.format(
+            NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
          True],
         # not normalized path root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}//..//',
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir2_name"]),
          [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
@@ -733,7 +736,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
           NO_DIRECTORY_FILENAME_LIST["testfile4_name"]],
          True],
         # not normalized path beyond root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}//..//../',
+        ['{}//..//../'.format(NO_DIRECTORY_FILENAME_LIST["dir2_name"]),
          [os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
@@ -769,12 +772,15 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
         # not exist but share the prefix
         ['t', FileNotFoundError],
         # broken path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//t/', FileNotFoundError],
+        ['{}//t/'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]),
+            FileNotFoundError],
         # list a file
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}///',  # NOQA
+        ['{}//{}///'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
          NotADirectoryError],
         # list a non_exist_dir but share the surfix
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}[:-1]/', FileNotFoundError]
+        ['{}/'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"][:-1]),
+         FileNotFoundError]
     ])
     def test_list_with_errors(self, path_or_prefix, error):
         with self.fs_handler.open_as_container(self.zip_file_name) as handler:
@@ -786,23 +792,27 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
 
     @parameterized.expand([
         # path ends with slash
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//', True],
+        ['{}//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}',  # NOQA
+        ['{}//{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
             False],
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}/{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}',  # NOQA
+        ['{}//..//{}/{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
             False],
         # problem 2 in issue #66
         [NO_DIRECTORY_FILENAME_LIST["dir1_name"], True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
+        ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
+            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
             True],
         # not normalized path root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//', False],
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), False],
         # not normalized path beyond root
         ['//..//', False],
         # not normalized path beyond root
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//', False],
+        ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), False],
         # starting with slash
         ['/', False]
     ])

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -655,8 +655,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
          [NO_DIRECTORY_FILENAME_LIST["testfile2_name"]],
          False],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//\
-           {NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
          False],
@@ -706,7 +705,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
          True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../', # NOQA
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           os.path.join(NO_DIRECTORY_FILENAME_LIST["dir2_name"],
                        NO_DIRECTORY_FILENAME_LIST["testfile2_name"])],
@@ -772,7 +771,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
         # broken path
         [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//t/', FileNotFoundError],
         # list a file
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}///', # NOQA
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}///',  # NOQA
          NotADirectoryError],
         # list a non_exist_dir but share the surfix
         [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}[:-1]/', FileNotFoundError]
@@ -789,14 +788,14 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
         # path ends with slash
         [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//', True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}', # NOQA
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}',  # NOQA
             False],
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}/{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}', # NOQA
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//{NO_DIRECTORY_FILENAME_LIST["dir2_name"]}/{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}',  # NOQA
             False],
         # problem 2 in issue #66
         [NO_DIRECTORY_FILENAME_LIST["dir1_name"], True],
         # not normalized path
-        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../', # NOQA
+        [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//{NO_DIRECTORY_FILENAME_LIST["testfile1_name"]}//../',  # NOQA
             True],
         # not normalized path root
         [f'{NO_DIRECTORY_FILENAME_LIST["dir1_name"]}//..//', False],

--- a/tests/container_tests/test_zip_container.py
+++ b/tests/container_tests/test_zip_container.py
@@ -656,7 +656,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
          False],
         # not normalized path
         ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
-            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+                              NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
          [NO_DIRECTORY_FILENAME_LIST["testfile1_name"],
           NO_DIRECTORY_FILENAME_LIST["dir2_name"]],
          False],
@@ -776,7 +776,7 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
             FileNotFoundError],
         # list a file
         ['{}//{}///'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
-            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+                            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
          NotADirectoryError],
         # list a non_exist_dir but share the surfix
         ['{}/'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"][:-1]),
@@ -795,18 +795,18 @@ class TestZipHandlerListNoDirectory(unittest.TestCase):
         ['{}//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), True],
         # not normalized path
         ['{}//{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
-            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
-            False],
+                         NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         False],
         ['{}//..//{}/{}'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
-            NO_DIRECTORY_FILENAME_LIST["dir2_name"],
-            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
-            False],
+                                NO_DIRECTORY_FILENAME_LIST["dir2_name"],
+                                NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         False],
         # problem 2 in issue #66
         [NO_DIRECTORY_FILENAME_LIST["dir1_name"], True],
         # not normalized path
         ['{}//{}//../'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"],
-            NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
-            True],
+                              NO_DIRECTORY_FILENAME_LIST["testfile1_name"]),
+         True],
         # not normalized path root
         ['{}//..//'.format(NO_DIRECTORY_FILENAME_LIST["dir1_name"]), False],
         # not normalized path beyond root


### PR DESCRIPTION
This PR fixes a bug which is related to non-directory-included zip, a
kind of zip that contains hierarchical structure but does not contain
the directories themselves. Such kind of zip can be made with "zip -D".

This PR fixes the bug when list or isdir to these "non-exist" directory
in such non-directory-included zip.

We do NOT handle the `exists` in this case as the directories do NOT `exist` **physically**
in the zip, but **logically** `exist`, we want to be honest on what is here and what is not. Also it helps to prevent users from accessing the `stat` of these kind of directory